### PR TITLE
ANS-006-121 - #34 #76 #106 - MAJ templateID et ID document + MAJ nomenclatures NOS + MAJ exemple

### DIFF
--- a/input/images/CDA_TDDUI_Exemple.xml
+++ b/input/images/CDA_TDDUI_Exemple.xml
@@ -33,11 +33,10 @@
 	            extension="version à renseigner"/>
 	<!-- Identifiant unique du document -->
 	<id root="1.2.250.2345.3245.13.58130.1"/>
-	<!-- Type de document (valeurs temporaires en attente d'une nomenclature plus adaptée) -->
-	<code code="EXPPAT_2"
-	      displayName="Autre document du patient"
-	      codeSystem="1.2.250.1.213.1.1.4.12"
-	      codeSystemName="JDV_J07-XdsTypeCode-CISIS"/>
+	<!-- Type de document -->
+	<code code="EXPORT_DUI"
+	      displayName="Export du Dossier Usager Informatisé"
+	      codeSystem="1.2.250.1.213.1.1.4.12"/>
 	<!-- Titre du document -->
 	<title>   Document transfert de données DUI </title>
 	<!-- Date de création du document -->
@@ -72,7 +71,7 @@
 					<family qualifier="CL">DECOURCY</family>
 					<given qualifier="CL">Ruth</given>
 				</name>
-				<!-- Genre administratif (valeurs temporaires, codeSystem en attente de modification (VSM et SFE non concordantes)) -->
+				<!-- Genre administratif -->
 				<administrativeGenderCode code="F"
 				                          displayName="Féminin"
 				                          codeSystem="2.16.840.1.113883.5.1"/>
@@ -101,8 +100,10 @@
 			<!--  identification du système du système  -->
 			<id root="1.2.250.1.71.4.2.1"
 			    extension="801234567897"/>
-			<!-- Système ou dispositif obligatoire provenant de la JDV_J01-XdsAuthorSpecialty-CISIS (nullFlavor solution temporaire) -->
-			<code nullFlavor="NA"/>
+			<!-- Système ou dispositif (obligatoire) provenant du JDV_J01-XdsAuthorSpecialty-CISIS -->
+			<code code="LOGICIEL_DUI"
+			displayName="Logiciel de Dossier Usager Informatisé"
+			codeSystem="1.2.250.1.213.1.1.4.6"/>
 			<!-- Obligatoire s'il s'agit d'un système -->
 			<assignedAuthoringDevice>
 				<manufacturerModelName> Nom du modèle ou du dispositif </manufacturerModelName>
@@ -135,13 +136,14 @@
 			<!-- identifiant du système responsable du document -->
 			<id root="1.2.34.5.67.8.9.10"
 			    extension="1.2.250.1.71.4.2.2/24.30"/>
-			<!-- Système ou dispositif obligatoire provenant de la JDV_J01-XdsAuthorSpecialty-CISIS (nullFlavor solution temporaire) -->
-			<code nullFlavor="NA"/>
+			<!-- Système ou dispositif provenant de la JDV_J01-XdsAuthorSpecialty-CISIS -->
+			<code code="LOGICIEL_DUI"
+			displayName="Logiciel de Dossier Usager Informatisé"
+			codeSystem="1.2.250.1.213.1.1.4.6"/>
 			<!-- Etablissement de rattachement du PS -->
 			<representedOrganization>
-				<id root="1.3.2"
-				    extension="1750803447"/>
-				<name>Hôpital Européen Georges Pompidou</name>
+				<id root="1.3.2" extension="362521879"/>
+				<name>Editeur de logiciel DUI</name>
 			</representedOrganization>
 		</assignedEntity>
 	</legalAuthenticator>
@@ -158,13 +160,14 @@
 					<!-- identifiant du système responsable du document -->
 					<id root="1.2.34.5.67.8.9.10"
 					    extension="1.2.250.1.71.4.2.2/24.30"/>
-					<!-- Système ou dispositif obligatoire provenant de la JDV_J01-XdsAuthorSpecialty-CISIS (nullFlavor solution temporaire) -->
-					<code nullFlavor="NA"/>
+					<!-- Système ou dispositif provenant de la JDV_J01-XdsAuthorSpecialty-CISIS -->
+					<code code="LOGICIEL_DUI"
+							displayName="Logiciel de Dossier Usager Informatisé"
+							codeSystem="1.2.250.1.213.1.1.4.6"/>
 					<!-- Etablissement de rattachement du PS -->
 					<representedOrganization>
-						<id root="1.3.2"
-						    extension="1750803447"/>
-						<name>Hôpital Européen Georges Pompidou</name>
+						<id root="1.3.2" extension="362521879"/>
+						<name>Editeur de logiciel DUI</name>
 					</representedOrganization>
 				</assignedEntity>
 			</performer>
@@ -181,10 +184,10 @@
 			<!-- Lieu de prise en charge  -->
 			<location>
 				<healthCareFacility>
-				<!-- Valeurs temporaires, en attente d'une nomenclature plus adaptée (JDV_J02) -->
-					<code code="SA41"
-					      codeSystem="1.2.250.1.71.4.2.4"
-					      displayName="Autre établissement du domaine social ou médico-social"/>
+				<!-- Valeur issue du JDV CI-SIS J254 -->
+					<code code="182"
+					      codeSystem="1.2.250.1.213.1.6.1.8"
+					      displayName="Service d'Éducation Spéciale et de Soins à Domicile"/>
 				</healthCareFacility>
 			</location>
 		</encompassingEncounter>

--- a/input/images/CDA_TDDUI_Exemple.xml
+++ b/input/images/CDA_TDDUI_Exemple.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-stylesheet type="text/xsl" href="../FeuilleDeStyle/CDA-FO.xsl"?>
 <!-- 
 	**********************************************************************************************************
 	Système : ANS

--- a/input/images/CDA_TDDUI_Exemple.xml
+++ b/input/images/CDA_TDDUI_Exemple.xml
@@ -29,10 +29,10 @@
 	<!-- Déclaration de conformité aux spécifications du CI-SIS -->
 	<templateId root="1.2.250.1.213.1.1.1.1"/>
 	<!-- Déclaration de conformité aux spécifications du modèle de document Transfert de données DUI -->
-	<templateId root="1.2.250.1.213.1.1.1.4.11"
+	<templateId root="1.2.250.1.213.1.1.1.58"
 	            extension="version à renseigner"/>
 	<!-- Identifiant unique du document -->
-	<id root="E20C5584-4278-11EE-BE56-0242AC120002" extension="0001"/>
+	<id root="1.2.250.2345.3245.13.58130.1"/>
 	<!-- Type de document (valeurs temporaires en attente d'une nomenclature plus adaptée) -->
 	<code code="EXPPAT_2"
 	      displayName="Autre document du patient"
@@ -50,7 +50,7 @@
 	<!-- Langue du document -->
 	<languageCode code="fr-FR"/>
 	<!-- Identifiant commun à toutes les versions successives du document -->
-	<setId root="E20C5584-4278-11EE-BE56-0242AC120002"/>
+	<setId root="1.2.250.2345.3245.13.58130"/>
 	<!-- Numéro de la version du présent document (entier positif) -->
 	<versionNumber value="1"/>
 	<!-- Usager -->

--- a/input/pagecontent/contenu_dossier_entete_cda.md
+++ b/input/pagecontent/contenu_dossier_entete_cda.md
@@ -601,7 +601,7 @@ L’élément legalAuthentificator imposé par le CDA représente le responsable
             <td>[0..1] </td>
             <td></td>
             <td><p><strong>Profession ou rôle du responsable</strong></p>
-			<p>@code = Code de issu du <a href="https://mos.esante.gouv.fr/NOS/JDV_J01-XdsAuthorSpecialty-CISIS/JDV_J01-XdsAuthorSpecialty-CISIS.pdf">JDV_J01-XdsAuthorSpecialtyCISIS</a><strong> (1.2.250.1.213.1.1.5.461)</strong>
+			<p>@code = Code issu du <a href="https://mos.esante.gouv.fr/NOS/JDV_J01-XdsAuthorSpecialty-CISIS/JDV_J01-XdsAuthorSpecialty-CISIS.pdf">JDV_J01-XdsAuthorSpecialtyCISIS</a><strong> (1.2.250.1.213.1.1.5.461)</strong>
 			<br>@displayName = libellé associé à ce code
 			<br>@codeSystem = identifiant de la terminologie d'origine de ce code</p></td>
         </tr>
@@ -744,10 +744,9 @@ L’élément legalAuthentificator imposé par le CDA représente le responsable
             <td><p><strong>Cadre d'exercice</strong>
 			<br>- Si le responsable est un professionnel : Cadre d'exercice
 			<br>- Si le responsable est un SNR : Non renseigné
-			<br>Valeur issue du <a href="https://mos.esante.gouv.fr/NOS/JDV_J04-XdsPracticeSettingCode-CISIS/JDV_J04-XdsPracticeSettingCode-CISIS.pdf">JDV_J04-XdsPracticeSettingCode-CISIS</a><strong> (1.2.250.1.213.1.1.5.467)</strong></p>
-			<p><red>@code = « ETABLISSEMENT »
-			<br>@displayName = « Etablissement de santé »
-			<br>@codeSystem = « 1.2.250.1.213.1.1.4.9 »</red></p></td>
+			<p>@code = code issu du <a href="https://mos.esante.gouv.fr/NOS/JDV_J254-CategorieEtablissementESSMSPH/JDV_J254-CategorieEtablissementESSMSPH.pdf">JDV_J254-CategorieEtablissementESSMSPH</a><strong> (1.2.250.1.213.3.4.218)</strong>
+			<br>@displayName = libellé associé à ce code
+			<br>@codeSystem = identifiant de la terminologie d'origine de ce code</p></td>
         </tr>
     </tbody>
 </table>
@@ -1145,9 +1144,9 @@ L’élément componentOf imposé par le CI-SIS représente l’association du d
 			<td>X</td>
 			<td><p><strong>Modalité d'exercice de la structure</strong>
 			<br><red>Attribut nullFlavor interdit</red></p>
-			<p>@code = Valeur issue du <a href="https://mos.esante.gouv.fr/NOS/JDV_J02-XdsHealthcareFacilityTypeCode-CISIS/JDV_J02-XdsHealthcareFacilityTypeCode-CISIS.pdf">JDV_J02-XdsHealthcareFacilityTypeCode-CISIS</a><strong> (1.2.250.1.213.1.1.5.466)</strong> et fixée à "<red>SA41</red>"
-			<br>@displayName = "<red>Autre établissement du domaine social ou médico-social</red>"
-			<br>@codeSystem = <red>1.2.250.1.71.4.2.4</red></p></td>
+			<p>@code = code issu du <a href="https://mos.esante.gouv.fr/NOS/JDV_J254-CategorieEtablissementESSMSPH/JDV_J254-CategorieEtablissementESSMSPH.pdf">JDV_J254-CategorieEtablissementESSMSPH</a><strong> (1.2.250.1.213.3.4.218)</strong>
+			<br>@displayName = libellé associé à ce code
+			<br>@codeSystem = identifiant de la terminologie d'origine de ce code</p></td>
 		</tr>
 	</tbody>
 </table>

--- a/input/pagecontent/contenu_dossier_entete_cda.md
+++ b/input/pagecontent/contenu_dossier_entete_cda.md
@@ -743,7 +743,7 @@ L’élément legalAuthentificator imposé par le CDA représente le responsable
             <td></td>
             <td><p><strong>Cadre d'exercice</strong>
 			<br>- Si le responsable est un professionnel : Cadre d'exercice
-			<br>- Si le responsable est un SNR : Non renseigné
+			<br>- Si le responsable est un SNR : Non renseigné</p>
 			<p>@code = code issu du <a href="https://mos.esante.gouv.fr/NOS/JDV_J254-CategorieEtablissementESSMSPH/JDV_J254-CategorieEtablissementESSMSPH.pdf">JDV_J254-CategorieEtablissementESSMSPH</a><strong> (1.2.250.1.213.3.4.218)</strong>
 			<br>@displayName = libellé associé à ce code
 			<br>@codeSystem = identifiant de la terminologie d'origine de ce code</p></td>
@@ -939,7 +939,7 @@ L’élément DocumentationOf imposé par le CDA décrit les données de l'évè
 			<td>[0..1] </td>
 			<td></td>
 			<td><p><strong>Identifiant de la structure</strong>
-			- Si l'exécutant est un professionnel : Identifiant de la structure pour le compte de laquelle intervient le professionnel.
+			<br>- Si l'exécutant est un professionnel : Identifiant de la structure pour le compte de laquelle intervient le professionnel.
 			<br>- Si l'exécutant est un SNR : SIREN de l'éditeur</p>
 			<p>@root = OID de la structure
 			<br>•Si l'exécutant est un professionnel :  "1.2.250.1.71.4.2.2" (OID autorité d'attribution des identifiants des structures, voir <a href="https://esante.gouv.fr/annexe-sources-des-donnees-personnes-et-structures">Annexe - sources des données personnes et structures</a>)

--- a/input/pagecontent/contenu_dossier_structure_cda.md
+++ b/input/pagecontent/contenu_dossier_structure_cda.md
@@ -144,9 +144,9 @@ Les éléments imposés par le standard CDA ou le CI-SIS sont indiqués par « *
 			<td>[1..1]</td>
 			<td>X</td>
 			<td><p><strong>Type de document</strong></p>
-			<p>@code = Code issu du <a href="https://mos.esante.gouv.fr/NOS/JDV_J07-XdsTypeCode-CISIS/JDV_J07-XdsTypeCode-CISIS.pdf">JDV_J07-XdsTypeCode-CISIS</a> fixé à « EXPPAT_2 »
-			<br>@displayName = « Autre document du patient »
-			<br>@codeSystem = 1.2.250.1.213.1.1.4.12</p></td>
+			<p><red>@code = Code issu du <a href="https://mos.esante.gouv.fr/NOS/JDV_J07-XdsTypeCode-CISIS/JDV_J07-XdsTypeCode-CISIS.pdf">JDV_J07-XdsTypeCode-CISIS</a> fixé à « EXPORT_DUI »
+			<br>@displayName = « Export du Dossier Usager Informatisé »
+			<br>@codeSystem = 1.2.250.1.213.1.1.4.12</red></p></td>
 		</tr>
 		<tr>
 			<td>1</td>

--- a/input/pagecontent/contenu_dossier_structure_cda.md
+++ b/input/pagecontent/contenu_dossier_structure_cda.md
@@ -123,7 +123,8 @@ Les éléments imposés par le standard CDA ou le CI-SIS sont indiqués par « *
 			<td>[1..1]</td>
 			<td>X</td>
 			<td><p><strong>Déclaration de conformité du document au modèle de document structuré MS-TD-DUI (Transfert de données DUI)</strong></p>
-			<p><red>@root = 1.2.250.1.213.1.1.1.4.11</red></p></td>
+			<p>@root = 1.2.250.1.213.1.1.1.58
+			<br>@extension (facultatif) = version du guide d'implémentation utilisé</p></td>
 		</tr>
 		<tr>
 			<td>1</td>
@@ -131,9 +132,10 @@ Les éléments imposés par le standard CDA ou le CI-SIS sont indiqués par « *
 			<td>II</td>
 			<td>[1..1]</td>
 			<td>X</td>
-			<td><p><strong>Identifiant unique du document</strong></p>
-			<p>@root (obligatoire) = valeur de l'OID propre à l'émetteur</p>
-			<p><red>Il est recommandé de générer une racine d'OID pour chaque ESSMS, à partir d'un <a  href="https://www.uuidgenerator.net/version1">générateur d'OID</a>. Cet OID devra être converti en majuscule afin de se conformer aux spécifications HL7. Il pourra ensuite être décliné pour identifier de façon unique chaque instance et version des documents de l'émetteur</red></p></td>
+			<td><p><strong>Identifiant unique du document</strong>
+			<br><red>Attribut nullFlavor interdit</red></p>
+			<p>@root (obligatoire) = valeur d'un OID propre à l'émetteur, formé d'un OID complet identifiant l'instance du document.
+			</p></td>
 		</tr>
 		<tr>
 			<td>1</td>
@@ -142,9 +144,9 @@ Les éléments imposés par le standard CDA ou le CI-SIS sont indiqués par « *
 			<td>[1..1]</td>
 			<td>X</td>
 			<td><p><strong>Type de document</strong></p>
-			<p><red>@code = Code issu du <a href="https://mos.esante.gouv.fr/NOS/JDV_J07-XdsTypeCode-CISIS/JDV_J07-XdsTypeCode-CISIS.pdf">JDV_J07-XdsTypeCode-CISIS</a> fixé à « EXPPAT_2 »
+			<p>@code = Code issu du <a href="https://mos.esante.gouv.fr/NOS/JDV_J07-XdsTypeCode-CISIS/JDV_J07-XdsTypeCode-CISIS.pdf">JDV_J07-XdsTypeCode-CISIS</a> fixé à « EXPPAT_2 »
 			<br>@displayName = « Autre document du patient »
-			<br>@codeSystem = 1.2.250.1.213.1.1.4.12</red></p></td>
+			<br>@codeSystem = 1.2.250.1.213.1.1.4.12</p></td>
 		</tr>
 		<tr>
 			<td>1</td>
@@ -172,9 +174,9 @@ Les éléments imposés par le standard CDA ou le CI-SIS sont indiqués par « *
 			<td>X</td>
 			<td><p><strong>Niveau de confidentialité du document.</strong>
 			<br>Code issu du JDV_HL7_Confidentiality-CISIS</p>
-			<p><red>@code = Valeur fixée à : « N »
+			<p>@code = Valeur fixée à : « N »
 			<br>@codeSystem = 2.16.840.1.113883.5.25 
-			<bR>@displayName = « Normal »</red></p></td>
+			<bR>@displayName = « Normal »</p></td>
 		</tr>
 		<tr>
 			<td>1</td>
@@ -191,8 +193,9 @@ Les éléments imposés par le standard CDA ou le CI-SIS sont indiqués par « *
 			<td>II</td>
 			<td>[0..1]</td>
 			<td></td>
-			<td><p><strong>Identification du lot de versions du même document</strong></p>
-			<p>@root = valeur de l'OID du lot de document propre à l'émetteur</p></td>
+			<td><p><strong>Identification du lot de versions du même document</strong>
+			<br><red>Attribut nullFlavor interdit</red></p>
+			<p>@root = valeur d'un OID propre à l'émetteur, formée d'un OID identifiant le lot de versions du document</p></td>
 		</tr>
 		<tr>
 			<td>1</td>


### PR DESCRIPTION
## Description des changements

* Modification du templateId de déclaration de conformité aux spécifications du modèle de document TDDUI
* MAJ des recommandations de gestion de l'id et le setID de document (format OID et non UUID)
* MAJ des spécifications et exemple pour prendre en compte les nouveaux codes et JDV NOS : 
     - assignedAuthor : JDV_J01 => nouveau code LOGICIEL_DUI
     - componentOf : JDV_J02 => remplacé par le JDV_J254
     - legalAuthenticator : JDV_J04 => remplacé par le JDV_J254
     - code Document : JDV_J07 => nouveau code EXPORT_DUI / JDV_J01 => nouveau code LOGICIEL_DUI

## Preview

https://ansforge.github.io/IG-fhir-medicosocial-transfert-donnees-dui/Contenu_MAJ_NOS_EvolANS/ig

