### PR TITLE
ANS-006-121 - #90 Autre ressources - ajouter l'onglet et uniformiser avec sdo

### DIFF
--- a/input/pagecontent/autres_ressources.md
+++ b/input/pagecontent/autres_ressources.md
@@ -1,0 +1,6 @@
+* <a href="securite.html">Sécurité</a>
+* <a href="downloads.html">Télerchargement et usages</a>
+* <a href="{{site.data.fhir.path}}index.html">Spécifications FHIR</a>
+* <a href="https://esante.gouv.fr/">Site de l'ANS</a>
+* <a href="https://interop.esante.gouv.fr/ig/documentation/">Documentation</a>
+

--- a/input/pagecontent/documentation.md
+++ b/input/pagecontent/documentation.md
@@ -1,0 +1,6 @@
+
+Si vous n'êtes pas redirigé automatiquement, [cliquez ici pour voir la documentation](https://interop.esante.gouv.fr/ig/documentation/).
+
+<script type="text/javascript">
+  window.location.href = "https://interop.esante.gouv.fr/ig/documentation/";
+</script>

--- a/input/pagecontent/securite.md
+++ b/input/pagecontent/securite.md
@@ -1,0 +1,6 @@
+Les données véhiculées à travers ces flux sont des données à caractère personnel contenant notamment des données médicales sensibles qu'il convient de protéger.
+
+Cette section présente les éventuelles recommandations de sécurité qui s'appliquent à cet Implementation Guidegit status
+. Il s'agit d'un sous-ensemble lié à la dimension interopérabilité de dispositions de sécurité plus globales visant à couvrir les exigences de sécurité d'un système cible.
+
+Il est du ressort du responsable de traitement du système cible de mettre en œuvre des dispositions de sécurité adaptées à son analyse de risques pour le service. En fonction de sa politique de sécurité, il peut choisir ou pas de mettre en œuvre les dispositions spécifiques décrites dans cette section. Les référentiels de sécurité édités par l'ANS fournissent des recommandations sur ce sujet. 

--- a/input/pagecontent/securite.md
+++ b/input/pagecontent/securite.md
@@ -1,5 +1,5 @@
 Les données véhiculées à travers ces flux sont des données à caractère personnel contenant notamment des données médicales sensibles qu'il convient de protéger.
 
-Cette section présente les éventuelles recommandations de sécurité qui s'appliquent à cet Implementation Guide git status. Il s'agit d'un sous-ensemble lié à la dimension interopérabilité de dispositions de sécurité plus globales visant à couvrir les exigences de sécurité d'un système cible.
+Cette section présente les éventuelles recommandations de sécurité qui s'appliquent à cet Implementation Guide. Il s'agit d'un sous-ensemble lié à la dimension interopérabilité de dispositions de sécurité plus globales visant à couvrir les exigences de sécurité d'un système cible.
 
 Il est du ressort du responsable de traitement du système cible de mettre en œuvre des dispositions de sécurité adaptées à son analyse de risques pour le service. En fonction de sa politique de sécurité, il peut choisir ou pas de mettre en œuvre les dispositions spécifiques décrites dans cette section. Les référentiels de sécurité édités par l'ANS fournissent des recommandations sur ce sujet.

--- a/input/pagecontent/securite.md
+++ b/input/pagecontent/securite.md
@@ -1,6 +1,5 @@
 Les données véhiculées à travers ces flux sont des données à caractère personnel contenant notamment des données médicales sensibles qu'il convient de protéger.
 
-Cette section présente les éventuelles recommandations de sécurité qui s'appliquent à cet Implementation Guidegit status
-. Il s'agit d'un sous-ensemble lié à la dimension interopérabilité de dispositions de sécurité plus globales visant à couvrir les exigences de sécurité d'un système cible.
+Cette section présente les éventuelles recommandations de sécurité qui s'appliquent à cet Implementation Guide git status. Il s'agit d'un sous-ensemble lié à la dimension interopérabilité de dispositions de sécurité plus globales visant à couvrir les exigences de sécurité d'un système cible.
 
-Il est du ressort du responsable de traitement du système cible de mettre en œuvre des dispositions de sécurité adaptées à son analyse de risques pour le service. En fonction de sa politique de sécurité, il peut choisir ou pas de mettre en œuvre les dispositions spécifiques décrites dans cette section. Les référentiels de sécurité édités par l'ANS fournissent des recommandations sur ce sujet. 
+Il est du ressort du responsable de traitement du système cible de mettre en œuvre des dispositions de sécurité adaptées à son analyse de risques pour le service. En fonction de sa politique de sécurité, il peut choisir ou pas de mettre en œuvre les dispositions spécifiques décrites dans cette section. Les référentiels de sécurité édités par l'ANS fournissent des recommandations sur ce sujet.

--- a/input/pagecontent/site_ans.md
+++ b/input/pagecontent/site_ans.md
@@ -1,0 +1,6 @@
+
+Si vous n'êtes pas redirigé automatiquement, [cliquez ici pour visiter le site de l'Agence du Numérique en Santé](https://esante.gouv.fr/).
+
+<script type="text/javascript">
+  window.location.href = "https://esante.gouv.fr/";
+</script>

--- a/input/pagecontent/specs_fhir.md
+++ b/input/pagecontent/specs_fhir.md
@@ -1,0 +1,6 @@
+
+Si vous n'êtes pas redirigé automatiquement, [cliquez ici pour voir les spécifications FHIR]({{site.data.fhir.path}}index.html).
+
+<script type="text/javascript">
+  window.location.href = "{{site.data.fhir.path}}index.html";
+</script>

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -97,4 +97,9 @@ menu:
         Acronymes: annexes_acronymes.html
         Spécifications FHIR : new-tab {{site.data.fhir.path}}index.html
         Site de l'ANS : new-tab https://esante.gouv.fr/
-    Documentation: new-tab https://interop.esante.gouv.fr/ig/documentation/
+    Autres ressources:
+        Sécurité: securite.html
+        Téléchargements et usage: downloads.html
+        "Spécifications FHIR ": new-tab {{site.data.fhir.path}}index.html
+        "Site de l'ANS ": new-tab https://esante.gouv.fr/
+        "Documentation": new-tab https://interop.esante.gouv.fr/ig/documentation/

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -70,6 +70,19 @@ pages:
             title: Nomenclatures de référence
         annexes_acronymes.md:
             title: Acronymes
+    autres_ressources.md:
+        title: Autres ressources
+        securite.md:
+            title: Sécurité
+        downloads.md:
+            title: Téléchargements et usages
+        specs_fhir.md:
+            title: Spécifications FHIR
+        site_ans.md:
+            title: Site de l'ANS
+        documentation.md:
+            title: Documentation
+
 
 menu:
     Accueil: index.html
@@ -95,11 +108,9 @@ menu:
         Documents de référence: annexes_documents_reference.html
         Nomenclatures de référence : annexes_nomenclatures.html
         Acronymes: annexes_acronymes.html
-        Spécifications FHIR : new-tab {{site.data.fhir.path}}index.html
-        Site de l'ANS : new-tab https://esante.gouv.fr/
     Autres ressources:
         Sécurité: securite.html
         Téléchargements et usage: downloads.html
-        "Spécifications FHIR ": new-tab {{site.data.fhir.path}}index.html
-        "Site de l'ANS ": new-tab https://esante.gouv.fr/
-        "Documentation": new-tab https://interop.esante.gouv.fr/ig/documentation/
+        Spécifications FHIR : new-tab {{site.data.fhir.path}}index.html
+        Site de l'ANS : new-tab https://esante.gouv.fr/
+        Documentation : new-tab https://interop.esante.gouv.fr/ig/documentation/


### PR DESCRIPTION
## Description des changements

- Création de l'onglet "Autres ressources" et intégration des pages "Sécurité", "Téléchargements et usage"

- Suppression de l'onglet "Documentation" et déplacement de la page dans le nouvel onglet "Autres ressources"

- Déplacement des pages "Spécifications FHIR", "Site de l'ANS" stockées dans l'onglet "Annexes" dans le nouvel onglet "Autres ressources"

- Mise à jour du Table of content pour prendre en compte la nouvelle architecture

- Création d'un mini script pour permettre la redirection vers le site de l'ans, la documentation et les spécs FHIR depuis le Table of content

## Preview

https://ansforge.github.io/IG-fhir-medicosocial-transfert-donnees-dui/AjoutOngletRessources/ig

