### PR TITLE
Suppression TRE_A04

### DIFF
--- a/input/fsh/Profiles/TDDUIDocumentReference.fsh
+++ b/input/fsh/Profiles/TDDUIDocumentReference.fsh
@@ -131,7 +131,6 @@ Severity:    #warning
 Invariant:   constr-bind-type
 Description: "Les valeurs possibles pour cet élément doivent provenir d’une des terminologies de référence suivantes :
 \r\n TRE_A05-TypeDocComplementaireCISIS, OID : 1.2.250.1.213.1.1.4.12
-\r\n TRE_A04-TypeDocument-LOINC, OID : 2.16.840.1.113883.6.1
 \r\n TRE_A12-NomenclatureASTM, OID : ASTM
 \r\nLes valeurs possibles peuvent être restreintes en fonction du jeu de valeurs correspondant mis à disposition par le projet (exemple : JDV_J66-TypeCode-DMP).\r\nEn l’absence de spécifications complémentaires, le jeu de valeurs JDV_J07-XdsTypeCode-CISIS peut être utilisé."
 XPath: "f:type"


### PR DESCRIPTION
## Description des changements

* Suppression de la TRE_A04 de la description

## Preview

https://ansforge.github.io/IG-fhir-medicosocial-transfert-donnees-dui/[ajouter_nom_de_la_branche]/ig

