### PR TITLE
Mise à jour sushi-config.yaml pour la publication

### DIFF
--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -15,7 +15,7 @@ releaseLabel: trial-use
 jurisdiction: urn:iso:std:iso:3166#FR "FRANCE"
 
 dependencies:
-    hl7.fhir.fr.core: 2.0.1
+    hl7.fhir.fr.core: 2.1.0
     ans.fr.nos: 1.2.0
 
 parameters:


### PR DESCRIPTION
## Description des changements

*  sushi-config.yaml :  version Fr-Core  2.1.0


## Preview

https://ansforge.github.io/IG-fhir-medicosocial-transfert-donnees-dui/[ajouter_nom_de_la_branche]/ig

