### PR TITLE
Ajout profession et rôle du PS

### DIFF
--- a/input/pagecontent/sfe_modelisation_contenu.md
+++ b/input/pagecontent/sfe_modelisation_contenu.md
@@ -1499,7 +1499,7 @@ Données d'identification pérennes d’une personne physique, qui travaille en 
    <tr>
     <td>civilite : [0..1] Code</td>
     <td>Civilité de la personne. <br>
-    Jeu(x) de valeur(s) associé(s) :  <a href="https://interop.esante.gouv.fr/ig/nos/ValueSet-JDV-J245-Civilite-CISIS.html">JDV_J245-Civilite-CISIS</a>
+    Jeu(x) de valeur(s) associé(s) :  <a href="https://mos.esante.gouv.fr/NOS/JDV_J245-Civilite-CISIS/JDV_J245-Civilite-CISIS.pdf">JDV_J245-Civilite-CISIS</a>
     </td>
   </tr>
    <tr>
@@ -1512,14 +1512,14 @@ Données d'identification pérennes d’une personne physique, qui travaille en 
   </tr>
    <tr>
     <td>profession : [0..1] Code</td>
-    <td>Profession du professionnel. <br>
-    Jeu(x) de valeur(s) associé(s) :  <a href="https://interop.esante.gouv.fr/ig/nos/ValueSet-JDV-J01-XdsAuthorSpecialty-CISIS.html">JDV_J01-XdsAuthorSpecialty-CISIS</a>
+    <td>Profession / Spécialité du professionnel. <br>
+    Jeu(x) de valeur(s) associé(s) :  <a href="https://mos.esante.gouv.fr/NOS/JDV_J01-XdsAuthorSpecialty-CISIS/JDV_J01-XdsAuthorSpecialty-CISIS.pdf">JDV_J01-XdsAuthorSpecialty-CISIS</a>
     </td>
   </tr>
   <tr>
     <td>role : [0..1] Code</td>
-    <td>Rôle du professionnel. <br>
-    Jeu(x) de valeur(s) associé(s) :  <a href="https://interop.esante.gouv.fr/ig/nos/ValueSet-JDV-J47-FunctionCode-CISIS.html">JDV-J47-FunctionCode-CISIS</a>
+    <td>Rôle fonctionnel du professionnel. <br>
+    Jeu(x) de valeur(s) associé(s) :  <a href="https://mos.esante.gouv.fr/NOS/JDV_J47-FunctionCode-CISIS/JDV_J47-FunctionCode-CISIS.pdf">JDV-J47-FunctionCode-CISIS</a>
     </td>
   </tr>
   <tr>

--- a/input/pagecontent/sfe_modelisation_contenu.md
+++ b/input/pagecontent/sfe_modelisation_contenu.md
@@ -1511,9 +1511,15 @@ Données d'identification pérennes d’une personne physique, qui travaille en 
     <td>Prénom usuel de la personne.</td>
   </tr>
    <tr>
-    <td>fonction : [0..1] Code</td>
-    <td>Profession / savoir-faire ou rôle du professionnel. <br>
+    <td>profession : [0..1] Code</td>
+    <td>Profession du professionnel. <br>
     Jeu(x) de valeur(s) associé(s) :  <a href="https://interop.esante.gouv.fr/ig/nos/ValueSet-JDV-J01-XdsAuthorSpecialty-CISIS.html">JDV_J01-XdsAuthorSpecialty-CISIS</a>
+    </td>
+  </tr>
+  <tr>
+    <td>role : [0..1] Code</td>
+    <td>Rôle du professionnel. <br>
+    Jeu(x) de valeur(s) associé(s) :  <a href="https://interop.esante.gouv.fr/ig/nos/ValueSet-JDV-J47-FunctionCode-CISIS.html">JDV-J47-FunctionCode-CISIS</a>
     </td>
   </tr>
   <tr>


### PR DESCRIPTION
## Description des changements
MAJ des spécifications fonctionnelles pour éclater l'élément "fonction" en 2 éléments "profession" et "rôle" du PS.

## Preview

https://ansforge.github.io/IG-fhir-medicosocial-transfert-donnees-dui/172-contenu-transporter-le-rôle-de-coordination-du-professionnel/ig

