### PR TITLE
SFE - numero sécurité sociale NIR et NIA de l'usager

### DIFF
--- a/input/images-source/bloc_identification_coordonnees.plantuml
+++ b/input/images-source/bloc_identification_coordonnees.plantuml
@@ -4,6 +4,8 @@ hide empty methods
 
 class Usager #LightPink {
     matriculeINS : Identifiant [0..1]
+    NSS-NIR : Identifiant [0..1]
+    NSS-NIA : Identifiant [0..1]
     identifiantLocalUsagerESSMS : Identifiant [0..1]
     numeroIndividuInitial : Identifiant [0..1]
     nomNaissance : Texte [1..1]

--- a/input/pagecontent/sfe_modelisation_contenu.md
+++ b/input/pagecontent/sfe_modelisation_contenu.md
@@ -34,7 +34,17 @@ L'usager est donc la personne qui reçoit une aide ou un accompagnement dans le 
     Si le matricule INS de l'usager existe, il doit être véhiculé en priorité. Dans le cas où le matricule INS est renseigné, les traits INS (traits d'identité et traits complémentaires issus du RNIV) doivent être transmis conformément à l'<a href="https://esante.gouv.fr/annexe-prise-en-charge-de-lins-dans-les-volets-du-ci-sis">annexe prise en charge de l'INS dans les volets du ci-sis</a>.
     </td>
   </tr>
-  <tr>
+<tr>
+    <td>NSS-NIR : [0..1] Identifiant</td>
+    <td>Numéro de sécurité social NIR de l'usager.
+    </td>
+  </tr>
+<tr>
+    <td>NSS-NIA : [0..1] Identifiant</td>
+    <td>Numéro de sécurité social NIA de l'usager en instance d’attribution d’un NIR.
+    </td>
+  </tr>
+<tr>
     <td>identifiantLocalUsagerESSMS : Identifiant [0..1]</td>
     <td>Identifiant local de l’usager au sein de la structure.<br>
     Cet identifiant est obtenu par la concaténation du type d'identifiant national de personne (provenant de la nomenclature TRE_G08-TypeIdentifiantPersonne), de l'identifiant de la structure (numéro FINESS), de l'identifiant local de l’usager au sein de la structure (identifiantLocalUsagerESSMS) : 3+FINESS/identifiantLocalUsagerESSMS</td>

--- a/input/pagecontent/sfe_modelisation_contenu.md
+++ b/input/pagecontent/sfe_modelisation_contenu.md
@@ -36,12 +36,12 @@ L'usager est donc la personne qui reçoit une aide ou un accompagnement dans le 
   </tr>
 <tr>
     <td>NSS-NIR : [0..1] Identifiant</td>
-    <td>Numéro de sécurité social NIR de l'usager.
+    <td>Numéro de sécurité sociale NIR de l'usager.
     </td>
   </tr>
 <tr>
     <td>NSS-NIA : [0..1] Identifiant</td>
-    <td>Numéro de sécurité social NIA de l'usager en instance d’attribution d’un NIR.
+    <td>Numéro de sécurité sociale NIA de l'usager en instance d’attribution d’un NIR.
     </td>
   </tr>
 <tr>


### PR DESCRIPTION
## Description des changements
SFE : Ajout du numéro de sécurité sociale de l'usager NIR et NIA.

## Preview

https://ansforge.github.io/IG-fhir-medicosocial-transfert-donnees-dui/179-contenu-gestion-du-nir-numéro-de-sécurité-sociale/ig

