### PR TITLE
SFE Indication permettant de véhiculer le rôle d'infirmier coordinateur

### DIFF
--- a/input/pagecontent/sfe_modelisation_contenu.md
+++ b/input/pagecontent/sfe_modelisation_contenu.md
@@ -1536,7 +1536,7 @@ Données d'identification pérennes d’une personne physique, qui travaille en 
   </tr>
 </table>
 
-Remarque : pour porter certains concepts comme IDEC (infirmier diplômé d'Etat de coordination), il convient d'enregistrer 2 informations (profession + rôle). IDEC = IDE (infirmier diplômé d'Etat) sur l'attribut profession avec le code infirmier du JDV_J01-XdsAuthorSpecialty-CISIS et le rôle de coordinateur sur l'attribut role avec le code du JDV_J47-FunctionCode-CISIS.
+Remarque : pour porter certains concepts comme IDEC (infirmier diplômé d'Etat de coordination), il convient d'enregistrer 2 informations (profession + rôle). IDEC = IDE (Infirmier diplômé d'Etat) sur l'attribut profession avec le code G15_60 (infirmier) du JDV_J01-XdsAuthorSpecialty-CISIS et le rôle de coordinateur sur l'attribut role avec le code 330 (Coordonnateur de parcours) du JDV_J47-FunctionCode-CISIS.
 
 ##### Classe Entité Juridique
 


### PR DESCRIPTION
## Description des changements
Mettre dans la SFE une indication permettant de véhiculer le rôle d'infirmier coordinateur

## Preview

https://ansforge.github.io/IG-fhir-medicosocial-transfert-donnees-dui/264-indication-permettant-de-véhiculer-le-rôle-dinfirmier-coordinateur/ig

