### PR TITLE
Suppression dépendance NOS pour référence au SMT

### DIFF
--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -16,7 +16,6 @@ jurisdiction: urn:iso:std:iso:3166#FR "FRANCE"
 
 dependencies:
     hl7.fhir.fr.core: 2.1.0
-    ans.fr.nos: 1.4.0
 
 parameters:
     shownav: 'true'


### PR DESCRIPTION
## Description des changements

Harmonisation des références aux JDV NOS et CI-SIS
Dépendance au NOS à supprimer
## Preview

https://ansforge.github.io/IG-fhir-medicosocial-transfert-donnees-dui/ESESuppression-dependance-NOS/ig

