### PR TITLE
Annexe professions MS qui n'existent pas dans reférentiels

### DIFF
--- a/input/pagecontent/annexes_codes_professions_roles_modes_exercices.md
+++ b/input/pagecontent/annexes_codes_professions_roles_modes_exercices.md
@@ -1,4 +1,4 @@
- Table de correspondance des codes professions médico-social n'ayant pas d'équivalence dans les référenciels officiels.
+ Table de correspondance des codes professions du médico-social n'ayant pas d'équivalence dans les référenciels officiels.
 
  <table>
 <tr>

--- a/input/pagecontent/annexes_codes_professions_roles_modes_exercices.md
+++ b/input/pagecontent/annexes_codes_professions_roles_modes_exercices.md
@@ -1,0 +1,43 @@
+ Table de correspondance des codes professions médico-social n'ayant pas d'équivalence dans les référenciels officiels.
+
+ <table>
+<tr>
+ <td rowspan="2">Code (Libellé)</td>
+        <td  colspan="3" align="center">Equivalence dans les référentiels officiels (NOS/CI-SIS)</td>
+    </tr>
+    <tr>
+        <td align="center">Profession</td>
+        <td align="center">Rôle</td>
+        <td align="center">Mode d'exercice</td>
+    </tr>
+<tr>
+        <td>IDE (Infirmier diplômé d'état)</td>
+        <td>infirmier (code G15_60 / <a href="https://ansforge.github.io/IG-terminologie-de-sante/ig/main/ValueSet-JDV-J01-XdsAuthorSpecialty-CISIS.html">JDV_J01-XdsAuthorSpecialty-CISIS</a>)</td>
+        <td></td>
+       <td></td>
+    </tr>
+<tr>
+        <td>IDEC (Infirmier diplômé d'état coordinateur)</td>
+        <td>infirmier (code G15_60 / <a href="https://ansforge.github.io/IG-terminologie-de-sante/ig/main/ValueSet-JDV-J01-XdsAuthorSpecialty-CISIS.html">JDV_J01-XdsAuthorSpecialty-CISIS</a>)</td>
+        <td>Coordonnateur de parcours (code 330 / <a href="https://ansforge.github.io/IG-terminologie-de-sante/ig/main/ValueSet-JDV-J47-FunctionCode-CISIS.html">JDV_J47-FunctionCode-CISIS</a>)</td>
+        <td></td>
+    </tr>
+<tr>
+           <td>IDEL (Infirmier libéral)</td>
+          <td>infirmier (code G15_60 / <a href="https://ansforge.github.io/IG-terminologie-de-sante/ig/main/ValueSet-JDV-J01-XdsAuthorSpecialty-CISIS.html">JDV_J01-XdsAuthorSpecialty-CISIS</a>)</td>
+         <td></td>
+         <td>Libéral (code L / <a href="https://ansforge.github.io/IG-terminologie-de-sante/ig/main/ValueSet-JDV-J117-ModeExercice-ENREG.html">JDV-J117-ModeExercice-ENREG</a>)</td>
+    </tr>
+<tr>
+        <td>Infirmier salarié</td>
+       <td>infirmier (code G15_60 / <a href="https://ansforge.github.io/IG-terminologie-de-sante/ig/main/ValueSet-JDV-J01-XdsAuthorSpecialty-CISIS.html">JDV_J01-XdsAuthorSpecialty-CISIS</a>)</td>
+       <td></td>
+      <td>Salarié (code S / <a href="https://ansforge.github.io/IG-terminologie-de-sante/ig/main/ValueSet-JDV-J117-ModeExercice-ENREG.html">JDV-J117-ModeExercice-ENREG</a>)</td>
+</tr>
+<tr>
+       <td>Infirmier bénévole</td>
+       <td>infirmier (code G15_60 / <a href="https://ansforge.github.io/IG-terminologie-de-sante/ig/main/ValueSet-JDV-J01-XdsAuthorSpecialty-CISIS.html">JDV_J01-XdsAuthorSpecialty-CISIS</a>)</td>
+       <td></td>
+      <td>Bénévole (code B / <a href="https://ansforge.github.io/IG-terminologie-de-sante/ig/main/ValueSet-JDV-J117-ModeExercice-ENREG.html">JDV-J117-ModeExercice-ENREG</a>)</td>
+</tr>
+</table>

--- a/input/pagecontent/sfe_modelisation_contenu.md
+++ b/input/pagecontent/sfe_modelisation_contenu.md
@@ -1575,6 +1575,12 @@ Données d'identification pérennes d’une personne physique, qui travaille en 
     </td>
   </tr>
   <tr>
+    <td>modeExercice : [0..1] Code</td>
+    <td>Mode d'exercice du professionnel. Décrit selon quelle modalité est excercée l'activité du professionnel par rapport à son établissement de rattachement.<br>
+    Jeu(x) de valeur(s) associé(s) :  <a href="https://ansforge.github.io/IG-terminologie-de-sante/ig/main/ValueSet-JDV-J117-ModeExercice-ENREG.html">JDV-J117-ModeExercice-ENREG</a>
+    </td>
+  </tr>
+  <tr>
     <td>etablissementDeRattachement : [0..1] EntiteJuridique</td>
     <td>Structure juridique de rattachement du professionnel.</td>
   </tr>

--- a/input/pagecontent/sfe_modelisation_contenu.md
+++ b/input/pagecontent/sfe_modelisation_contenu.md
@@ -1580,7 +1580,7 @@ Données d'identification pérennes d’une personne physique, qui travaille en 
   </tr>
 </table>
 
-<u>Remarque</u>: Certaines professions du médico-social n'ont pas de correspondance directe dans les référentiels du CI-SIS. L'annexe donne la correspondance entre la profession du médico-social et le triptyque "profession/rôle/mode d'exercice" référencé dans les jeux de valeurs du CI-SIS.
+<u>Remarque</u>: Certaines professions du médico-social n'ont pas de correspondance directe dans les référentiels du CI-SIS. L'annexe <a href="annexes_codes_professions_roles_modes_exercices.html">Professions du médico-social</a> donne la correspondance entre la profession du médico-social et le triptyque "profession/rôle/mode d'exercice" référencé dans les jeux de valeurs du CI-SIS.
 
 ##### Classe Entité Juridique
 

--- a/input/pagecontent/sfe_modelisation_contenu.md
+++ b/input/pagecontent/sfe_modelisation_contenu.md
@@ -1580,6 +1580,8 @@ Données d'identification pérennes d’une personne physique, qui travaille en 
   </tr>
 </table>
 
+<u>Remarque</u>: Certaines professions du médico-social n'ont pas de correspondance directe dans les référentiels du CI-SIS. L'annexe donne la correspondance entre la profession du médico-social et le triptyque "profession/rôle/mode d'exercice" référencé dans les jeux de valeurs du CI-SIS.
+
 ##### Classe Entité Juridique
 
 Pour ce volet l'Entité Juridique est une personne morale inscrite dans le FINESS.

--- a/input/pagecontent/sfe_modelisation_contenu.md
+++ b/input/pagecontent/sfe_modelisation_contenu.md
@@ -1576,7 +1576,7 @@ Données d'identification pérennes d’une personne physique, qui travaille en 
   </tr>
   <tr>
     <td>modeExercice : [0..1] Code</td>
-    <td>Mode d'exercice du professionnel. Décrit selon quelle modalité est excercée l'activité du professionnel par rapport à son établissement de rattachement.<br>
+    <td>Mode d'exercice du professionnel. Décrit selon quelle modalité est exercée l'activité du professionnel par rapport à son établissement de rattachement.<br>
     Jeu(x) de valeur(s) associé(s) :  <a href="https://ansforge.github.io/IG-terminologie-de-sante/ig/main/ValueSet-JDV-J117-ModeExercice-ENREG.html">JDV-J117-ModeExercice-ENREG</a>
     </td>
   </tr>

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -90,6 +90,8 @@ pages:
             title: Nomenclatures de référence
         annexes_acronymes.md:
             title: Acronymes
+        annexes_codes_professions_roles_modes_exercices.md:
+            title: Professions du médico-social
     autres_ressources.md:
         title: Autres ressources
         securite.md:
@@ -134,6 +136,7 @@ menu:
         Documents de référence: annexes_documents_reference.html
         Nomenclatures de référence : annexes_nomenclatures.html
         Acronymes: annexes_acronymes.html
+        Professions du médico-social : annexes_codes_professions_roles_modes_exercices.html
     Autres ressources:
         Sécurité: securite.html
         Téléchargements et usage: downloads.html


### PR DESCRIPTION
## Description des changements
Table de correspondance des professions" qui n'existent pas dans les référentiels dans l'annexe et le référencer dans la SFE.

## Preview

https://ansforge.github.io/IG-fhir-medicosocial-transfert-donnees-dui/tableau-correspondance-professions-roles/ig

