### PR TITLE
Mise à jour de la dépendance avec l'IG terminonogies

### DIFF
--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -16,7 +16,7 @@ jurisdiction: urn:iso:std:iso:3166#FR "FRANCE"
 
 dependencies:
     hl7.fhir.fr.core: 2.1.0
-    ans.fr.terminologies: 1.0.0
+    ans.fr.terminologies: 1.1.0
 
 parameters:
     shownav: 'true'


### PR DESCRIPTION
## Description des changements
La dépendance au NOS est obsolète ans.fr.nos: 1.4.0. Elle est remplacée par l'IG terminologies, dernière version
https://interop.esante.gouv.fr/terminologies/ : ans.fr.terminologies:1.0.0

## Preview

https://ansforge.github.io/IG-fhir-medicosocial-transfert-donnees-dui/322-paramétrage-ig/ig

