### PR TITLE
Remise des anciens noms : mode entrée et mode sortie du séjour

### DIFF
--- a/input/images-source/bloc_sejours.plantuml
+++ b/input/images-source/bloc_sejours.plantuml
@@ -23,10 +23,10 @@ class Sejour #Thistle {
     dateAdmission : DateHeure [0..1]
     dateEntreePrevisionnelle : DateHeure [0..1]
     dateEntree : DateHeure [0..1]
-    modeEntree : Texte [0..1]
+    libelleModeEntree : Texte [0..1]
     dateSortiePrevisionnelle : DateHeure [0..1]
     dateSortie : DateHeure [0..1]
-    modeSortie : Texte [0..1]
+    libelleModeSortie : Texte [0..1]
     commentaire : Texte [0..1] 
 }
 

--- a/input/images-source/flux1.plantuml
+++ b/input/images-source/flux1.plantuml
@@ -1,6 +1,6 @@
 @startuml
 
 "Logiciel DUI" -> "SI tiers" : Flux 1.1 **TransmissionDeDonnéesDUI**
-"Logiciel DUI" <-- "SI tiers" : Flux 1.2 **ResultatAjoutTransmissionDeDonnéesDUI**
+"Logiciel DUI" <-- "SI tiers" : Flux 1.2 **ResultatTransmissionDeDonnéesDUI**
 
 @enduml

--- a/input/pagecontent/sfe_modelisation_contenu.md
+++ b/input/pagecontent/sfe_modelisation_contenu.md
@@ -1049,7 +1049,7 @@ La classe EntiteJuridique est définie dans le MOS et est profilée pour ce vole
     <td>Date d’entrée dans le séjour.</td>
   </tr>
   <tr>
-    <td>modeEntree : [0..1] Texte</td>
+    <td>libelleModeEntree : [0..1] Texte</td>
     <td>Libellé du mode d’entée du séjour.</td>
   </tr>
   <tr>
@@ -1061,7 +1061,7 @@ La classe EntiteJuridique est définie dans le MOS et est profilée pour ce vole
     <td>Date de sortie du séjour.</td>
   </tr>
   <tr>
-    <td>modeSortie : [0..1] Texte</td>
+    <td>libelleModeSortie : [0..1] Texte</td>
     <td>Libellé du mode de sortie du séjour.</td>
   </tr>
   <tr>

--- a/input/pagecontent/sfe_transfert_des_donnees_a_un_tiers.md
+++ b/input/pagecontent/sfe_transfert_des_donnees_a_un_tiers.md
@@ -55,16 +55,6 @@ Le rôle de producteur incarné par un système est l’acteur à l’origine de
 
 Le rôle de consommateur incarné par un système est de réceptionner et d’importer les données dans son système (SI-tiers). 
 
-<table style="width:100%">
-  <tr>
-    <th>Processus collaboratif</th>
-    <th>Demandeur</th>
-  </tr>
-  <tr>
-    <td>Export des données d’un logiciel DUI</td>
-  </tr>
-</table>
-
 ### Identification des flux
 
 <table style="width:100%">


### PR DESCRIPTION
## Description des changements

Retour arrière sur le nommage des attributs : mode entrée et mode de sortie du séjour afin de ne pas impacter le mapping CDA.

## Preview

https://ansforge.github.io/IG-fhir-medicosocial-transfert-donnees-dui/mode-entree-sortie-sejour/ig




