### PR TITLE
Renommage de l'ordre de naissance

### DIFF
--- a/input/images-source/bloc_identification_coordonnees.plantuml
+++ b/input/images-source/bloc_identification_coordonnees.plantuml
@@ -15,7 +15,7 @@ class Usager #LightPink {
     sexe : Code [0..1]
     civilite : Code [0..1]
     dateNaissance : Date [0..1]
-    ordreNaissance : Numerique [0..1]
+    ordreNaissanceEtatCivil : Numerique [0..1]
     communeNaissance : Code [0..1]
     departementNaissance : Code [0..1]
     paysNaissance : Code [0..1]

--- a/input/pagecontent/sfe_modelisation_contenu.md
+++ b/input/pagecontent/sfe_modelisation_contenu.md
@@ -102,7 +102,7 @@ Synonymes : résident, résident AN, personne accompagnée, personne accueillie,
     Il est préconisé si le NIR ou l'identifiant local est véhiculé et que l'identité n'est pas qualifiée.</td>
   </tr>
    <tr>
-    <td>ordreNaissance : [0..1] Numerique </td>
+    <td>ordreNaissanceEtatCivil : [0..1] Numerique </td>
     <td>Ordre d’enregistrement de la naissance dans le registre d’état civil de la commune de naissance pour le mois de la naissance. Il compose les <a href="https://www.ameli.fr/llle-et-vilaine/assure/droits-demarches/principes/numero-securite-sociale">3 derniers chiffres du NIR de l'usager avant </a> la clé de sécurité et permet de distinguer les personnes nées au même lieu et à la même période.<br>
     Il est obligatoire si le NIR n'est pas transmis.</td>
   </tr>


### PR DESCRIPTION
## Description des changements
Ordre de naissance est renommé en ordre de naissance état civil suite atelier ANS/Kereval du 8/07/2025

## Preview

https://ansforge.github.io/IG-fhir-medicosocial-transfert-donnees-dui/338-renommer-ordrenaissance-en-ordrenaissanceetatcivil/ig

