### PR TITLE
ANS-006-150 - Correction HTTPS

### DIFF
--- a/input/pagecontent/description_flux_1_transmission_donnees_dui.md
+++ b/input/pagecontent/description_flux_1_transmission_donnees_dui.md
@@ -18,6 +18,6 @@ Les ressources utilisables sont :
 
 ### Flux 1.2 Resultat de la transmission de données DUI
 
-Si la création des ressources contenue dans le Bundle est correctement effectuée, le Consommateur doit retourner un code HTTPS 201 « Created » ainsi que les ressources créées avec les attributs `id`, `lastUpdated` et `versionId` mis à jour.
+Si la création des ressources contenue dans le Bundle est correctement effectuée, le Consommateur doit retourner un code HTTP 201 « Created » ainsi que les ressources créées avec les attributs `id`, `lastUpdated` et `versionId` mis à jour.
 
-En cas d’échec, le Consommateur doit répondre avec le code HTTPS approprié tel que défini par l’API REST FHIR [(Http - FHIR v4.0.1 (hl7.org))](http://hl7.org/fhir/R4/http.html). Une ressource OperationOutcome doit également y être associé pour véhiculer les messages d’erreurs détaillant la raison de l’erreur [(OperationOutcome - FHIR v4.0.1 (hl7.org))](http://hl7.org/fhir/R4/operationoutcome.html).
+En cas d’échec, le Consommateur doit répondre avec le code HTTP approprié tel que défini par l’API REST FHIR [(Http - FHIR v4.0.1 (hl7.org))](http://hl7.org/fhir/R4/http.html). Une ressource OperationOutcome doit également y être associé pour véhiculer les messages d’erreurs détaillant la raison de l’erreur [(OperationOutcome - FHIR v4.0.1 (hl7.org))](http://hl7.org/fhir/R4/operationoutcome.html).

--- a/input/pagecontent/description_flux_synthese.md
+++ b/input/pagecontent/description_flux_synthese.md
@@ -1,4 +1,4 @@
-**Les flux présentés ci dessous doivent utiliser HTTPS**
+**Les flux présentés ci-dessous doivent utiliser HTTPS**
 
 <table style="width:100%">
   <tr>

--- a/input/pagecontent/description_flux_synthese.md
+++ b/input/pagecontent/description_flux_synthese.md
@@ -1,3 +1,5 @@
+**Les flux présentés ci dessous doivent utiliser HTTPS**
+
 <table style="width:100%">
   <tr>
     <th>Processus métier</th>

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -95,7 +95,7 @@ Les flux décrits dans ce guide d'implémentation sont les suivants.
 | ----- | ----- | ----- |
 | <a href="description_flux_1_transmission_donnees_dui.html">Flux 1 : Transmission de données DUI</a> | Logiciel DUI | SI tiers |
 
-**Les flux présentés dans cette spécification doivent utiliser HTTPS**
+Les flux présentés dans cette spécification doivent utiliser HTTPS.
 Pour en savoir davantage, rendez-vous sur la page <a href="description_flux_synthese.html">Synthèse des flux</a>.
 
 ### Dépendances

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -74,8 +74,7 @@ Les spécifications d'interopérabilité présentées dans ce volet ne présagen
 
 Les données véhiculées dans ce volet ainsi que les interactions entre les systèmes reposent sur le standard HL7 FHIR Release 4.
 
-Les interactions font référence à un certain nombre de ressources du standard ainsi qu’aux spécifications de l’API REST FHIR, basées sur le protocole HTTP. Les syntaxes retenues sont la syntaxe XML et JSON.
-
+Les interactions font référence à un certain nombre de ressources du standard ainsi qu’aux spécifications de l’API REST FHIR, basées sur le protocole HTTP dans sa version sécurisée HTTPS. Les syntaxes retenues sont la syntaxe XML et JSON.
 #### Ressources FHIR profilées
 
 Les ressources profilées dans le cadre de ce guide d'implémentation sont les suivantes : 
@@ -96,6 +95,7 @@ Les flux décrits dans ce guide d'implémentation sont les suivants.
 | ----- | ----- | ----- |
 | <a href="description_flux_1_transmission_donnees_dui.html">Flux 1 : Transmission de données DUI</a> | Logiciel DUI | SI tiers |
 
+**Les flux présentés dans cette spécification doivent utiliser HTTPS**
 Pour en savoir davantage, rendez-vous sur la page <a href="description_flux_synthese.html">Synthèse des flux</a>.
 
 ### Dépendances


### PR DESCRIPTION
## Description des changements

* Ajout de 2 mentions sur l'index pour définir l'utilisation de HTTPS
* Ajout d'une mention sur la page description_flux_synthese
* ...

## Preview

https://ansforge.github.io/IG-fhir-medicosocial-transfert-donnees-dui/349-flux---remplacer-http-par-https/ig

