### PR TITLE
ANS-006-150 - Héritage TDDUIPatientINS

### DIFF
--- a/input/fsh/Profiles/TDDUIPatient.fsh
+++ b/input/fsh/Profiles/TDDUIPatient.fsh
@@ -4,7 +4,7 @@ Id: tddui-patient
 Title: "TDDUI Patient"
 Description: "Profil de la ressource FrCorePatientProfile permettant de représenter un usager lorsque l'INS n'est pas transmis."
 
-* insert TDDUIPatientIdSlices
+* insert TDDUIPatientCommonConstraints
 * birthDate.extension contains
     TDDUIBirthOrder named tddui-birth-order 1..1
 
@@ -14,8 +14,6 @@ Description: "Profil de la ressource FrCorePatientProfile permettant de représe
 * gender ^short = "male | female | unknown"
 
 * name[officialName] 1..1
-* name[usualName] 0..1
-* name only tddui-humanname
 
 Mapping:  ConceptMetier_TDDUIPatient
 Source:   TDDUIPatient

--- a/input/fsh/Profiles/TDDUIPatientINS.fsh
+++ b/input/fsh/Profiles/TDDUIPatientINS.fsh
@@ -4,21 +4,11 @@ Id: tddui-patient-ins
 Title: "TDDUI Patient INS"
 Description: "Profil de la ressource FRCorePatientINSProfile permettant de représenter un usager lorsque l'INS est transmis."
 
-* extension contains
-    $imposeProfile named impose-profile 0..1
-* extension[impose-profile].valueCanonical = Canonical(tddui-patient)
-
-* meta.profile contains tddui-patient-canonical 0..1
-* meta.profile[tddui-patient-canonical] = Canonical(tddui-patient)
-
-* insert TDDUIPatientIdSlices
+* insert TDDUIPatientCommonConstraints
 * identifier[INS-NIR] 0..1
 * identifier[INS-NIR-TEST] 0..1
 * identifier[INS-NIR-DEMO] 0..1
 * identifier[INS-NIA] 0..1
-
-* name[usualName] 0..1
-* name only tddui-humanname
 
 Mapping:  ConceptMetier_TDDUIPatientINS
 Source:   TDDUIPatientINS

--- a/input/fsh/RuleSet/TDDUIPatientCommonConstraints.fsh
+++ b/input/fsh/RuleSet/TDDUIPatientCommonConstraints.fsh
@@ -1,5 +1,5 @@
 
-RuleSet: TDDUIPatientIdSlices
+RuleSet: TDDUIPatientCommonConstraints
 
 
 * identifier contains
@@ -12,3 +12,6 @@ RuleSet: TDDUIPatientIdSlices
 * identifier[InitialNumberMDPH].type = TDDUIIdentifier#PIN "Patient initial number"
 * identifier[InitialNumberMDPH].system 1..
 * identifier[InitialNumberMDPH].value 1..
+
+* name[usualName] 0..1
+* name only tddui-humanname


### PR DESCRIPTION
## Description des changements

* Suppression du meta.profile pour TDDUIPatientINS
* RuleSet avec les contraintes communes

## Preview

https://ansforge.github.io/IG-fhir-medicosocial-transfert-donnees-dui/351-SD-HéritageTDDUIPatientINS/ig

