### PR TITLE
ANS-006-168 - Paramètre pin-all

### DIFF
--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -23,7 +23,6 @@ dependencies:
 parameters:
     shownav: 'true'
     path-expansion-params: '../../expansion-params.json' # for using French SNOMED CT Extension
-    pin-canonicals: 'pin-all'
 
 pages:
     index.md:


### PR DESCRIPTION
## Description des changements

* Suppression du paramètre pin-all du sushi-config

## Preview

https://ansforge.github.io/IG-fhir-medicosocial-transfert-donnees-dui/426-config---paramètre-pin-all/ig

