### PR TITLE
ANS-006-168 - Mise à jour de la cardinalité de Patient.birthDate

### DIFF
--- a/input/fsh/Profiles/TDDUIPatient.fsh
+++ b/input/fsh/Profiles/TDDUIPatient.fsh
@@ -5,6 +5,9 @@ Title: "TDDUI Patient"
 Description: "Profil de la ressource FrCorePatientProfile permettant de représenter un usager lorsque l'INS n'est pas transmis."
 
 * insert TDDUIPatientCommonConstraints
+
+* birthDate 1..1
+
 * birthDate.extension contains
     TDDUIBirthOrder named tddui-birth-order 1..1
 

--- a/input/fsh/instances/TDDUIPatientExample.fsh
+++ b/input/fsh/instances/TDDUIPatientExample.fsh
@@ -27,7 +27,6 @@ Usage: #example
 * name[officialName].extension[birth-list-given-name].valueString = "Jean Stéphane Patrick"
 
 * gender = #male
-* birthDate = "1947-04-03"
 * birthDate.extension[tddui-birth-order].valuePositiveInt = 2
 
 * address.use = #home

--- a/input/fsh/instances/TDDUIPatientPPImeExample.fsh
+++ b/input/fsh/instances/TDDUIPatientPPImeExample.fsh
@@ -10,3 +10,6 @@ Usage: #example
 * name[officialName].use = #official
 * name[officialName].given = "Hugo"
 * name[officialName].family = "D."
+
+* birthDate = "2005-09-15"
+* birthDate.extension[tddui-birth-order].valuePositiveInt = 1

--- a/input/fsh/instances/TDDUIPatientPPPAExample.fsh
+++ b/input/fsh/instances/TDDUIPatientPPPAExample.fsh
@@ -12,3 +12,6 @@ Usage: #example
 * name[officialName].given = "Jeanne"
 
 * gender = #female
+
+* birthDate = "1947-04-03"
+* birthDate.extension[tddui-birth-order].valuePositiveInt = 1


### PR DESCRIPTION
## Besoin 
* L'élément ordreNaissanceEtatCivil est requis si le NIR n'est pas transmis. Le profil TDDUIPatient est utilisé lorsque l'INS n'est pas transmis. L'ordreNaissanceEtatCivil doit donc être requis dans ce profil.

## Description des changements
* Passage de la cardinalité de l'élément Patient.birthdate à 1..1 du profil TDDUIPatient
    * Cette modification permet de rendre obligatoire l'extension tddui-birth-order mais n'impose pas le renseignement de l'élément birthDate
* Mise à jour des exemples du TDDUIPatient

## Preview

https://ansforge.github.io/IG-fhir-medicosocial-transfert-donnees-dui/441-rc---tdduipatient-birthdate/ig

