### PR TITLE
lot2 SFE modification role participant

### DIFF
--- a/input/images-source/bloc_evenement.plantuml
+++ b/input/images-source/bloc_evenement.plantuml
@@ -68,7 +68,7 @@ EntiteJuridique <|-- StructureEnCharge
 
 Evenement "*" -- "1" Usager
 Participant "*" -- "1..*" Evenement
-Professionnel "0..*" -- "1" Participant
+Professionnel "0..1" -- "*" Participant
 
 
 TransportUsager "*" -- "1" Evenement
@@ -79,6 +79,6 @@ Evenement "0..1" -- "0..1" Evaluation
 Evenement "1" -- "*" Statut
 
 StructureEnCharge "0..1" -- "*" Participant
-
+StructureEnCharge "0..1" -- "*" Professionnel
 
 @enduml

--- a/input/pagecontent/sfe_modelisation_contenu.md
+++ b/input/pagecontent/sfe_modelisation_contenu.md
@@ -1873,6 +1873,7 @@ Les classes EntiteJuridique, Lieu et Professionnel sont issues du MOS et sont pr
 ##### Classe Participant
 
 Le Participant est une personne morale ou physique prenant part à l'événement.
+
 Si le participant est mandaté par une personne morale, la notion de Mandataire est indiquée par le lien vers le Professionnel -> profession (code 307 - Mandataire judiciaire à la protection des majeurs (MJPM) : JDV_J01-XdsAuthorSpecialty-CISIS).
 
 <table style="width:100%">
@@ -1892,7 +1893,7 @@ Si le participant est mandaté par une personne morale, la notion de Mandataire 
 
 ** Classe spécialisée, hérite de la classe EntiteJuridique qui est issue du MOS et qui est profilée pour ce volet.
 
-Cette classe correspond à la structure en charge de l'évènement. Cette structure peut être différente de la structure de rattachement de l'usager.
+Cette classe correspond à la structure en charge de l'évènement. Cette structure peut être différente de la structure de rattachement de l'usager. Une seule structure en charge est renseignée par événement.
 
 Le lien est créé entre la classe Professionnel et la classe StructureEnCharge si le participant en tant que personne physique est interne à la structure en charge de l'évènement. Dans le cas contraire ce lien n'est pas créé.
 


### PR DESCRIPTION
## Description des changements

Selon le cas d'usage transmis par la CNSA le rôle du participant à l'événement est à modifier:

suppression de l'attribut roleParticipantEJ
0..1 participant de type EntiteJuridique pour la structure en charge
0..* participant de type Professionnel
La notion de Mandataire est indiquée par le lien vers le Professionnel -> profession (code 307 - Mandataire judiciaire à la protection des majeurs (MJPM) : [JDV_J01-XdsAuthorSpecialty-CISIS](https://mos.esante.gouv.fr/NOS/JDV_J01-XdsAuthorSpecialty-CISIS/FHIR/JDV-J01-XdsAuthorSpecialty-CISIS))

## Preview

https://ansforge.github.io/IG-fhir-medicosocial-transfert-donnees-dui/443-sfe-lot-2-modification-du-role-du-participant-de-levenement/ig

