### PR TITLE
ANS-006-168 - Ajout du projet de vie

### DIFF
--- a/Requirements-fromNarrative.json
+++ b/Requirements-fromNarrative.json
@@ -1,0 +1,10 @@
+{
+  "resourceType" : "Requirements",
+  "id" : "fromNarrative",
+  "url" : "https://interop.esante.gouv.fr/ig/fhir/tddui/Requirements/fromNarrative",
+  "name" : "FromNarrative",
+  "title" : "Narrative Conformance Statements",
+  "status" : "active",
+  "experimental" : false,
+  "description" : "Conformance statements found throughout the narrative of the IG consolidated into this computable resource for traceability purposes"
+}

--- a/input/fsh/CapabilityStatement/TDDUIConsommateur.fsh
+++ b/input/fsh/CapabilityStatement/TDDUIConsommateur.fsh
@@ -69,6 +69,7 @@ Usage: #definition
 * rest.resource[10].type = #Goal
 * rest.resource[=].supportedProfile[0] = Canonical(tddui-goal-attente)
 * rest.resource[=].supportedProfile[+] = Canonical(tddui-goal-objectif)
+* rest.resource[=].supportedProfile[+] = Canonical(tddui-goal-projet-vie)
 * rest.resource[=].interaction[0].code = #read
 
 * rest.resource[11].type = #ServiceRequest

--- a/input/fsh/CapabilityStatement/TDDUIProducteur.fsh
+++ b/input/fsh/CapabilityStatement/TDDUIProducteur.fsh
@@ -68,6 +68,7 @@ Usage: #definition
 * rest.resource[10].type = #Goal
 * rest.resource[=].supportedProfile[0] = Canonical(tddui-goal-attente)
 * rest.resource[=].supportedProfile[+] = Canonical(tddui-goal-objectif)
+* rest.resource[=].supportedProfile[+] = Canonical(tddui-goal-projet-vie)
 * rest.resource[=].interaction[0].code = #create
 
 * rest.resource[11].type = #ServiceRequest

--- a/input/fsh/CodeSystem/TDDUIGoalIdentifier.fsh
+++ b/input/fsh/CodeSystem/TDDUIGoalIdentifier.fsh
@@ -1,0 +1,11 @@
+CodeSystem: TDDUIGoalIdentifier
+Id: tddui-goal-identifier
+Title: "TDDUI Goal Identifier"
+Description: "CodeSystem pour la défintion des identifiants de la ressource Goal"
+* ^meta.profile = "http://hl7.org/fhir/StructureDefinition/shareablecodesystem"
+
+* ^caseSensitive = true
+* ^content = #complete
+* ^experimental = false
+
+* #PDV "Identifiant du projet de vie"

--- a/input/fsh/Profiles/TDDUIBundle.fsh
+++ b/input/fsh/Profiles/TDDUIBundle.fsh
@@ -34,8 +34,8 @@ Description: "Profil générique créé pour transmettre des données d'un logic
     DUIRelatedPersonContact 0..* and 
     DUIObservationCauseMortalite 0..* and
     DUIObservationPeriodeScolaire 0..* and
-    DUIObservationMobiliteUsager 0..*
-
+    DUIObservationMobiliteUsager 0..* and 
+    DUIGoalProjetVie 0..*
 
 
 * entry[DUIPatient].resource only TDDUIPatient
@@ -181,3 +181,9 @@ Description: "Profil générique créé pour transmettre des données d'un logic
 * entry[DUIObservationMobiliteUsager].resource 1..1
 * entry[DUIObservationMobiliteUsager].request 1..1
 * entry[DUIObservationMobiliteUsager].request.method = #POST
+
+* entry[DUIGoalProjetVie].resource only TDDUIGoalProjetVie
+* entry[DUIGoalProjetVie] ^short = "Goal conforming to the TDDUIGoalProjetVie profile, used to convey the life project."
+* entry[DUIGoalProjetVie].resource 1..1
+* entry[DUIGoalProjetVie].request 1..1
+* entry[DUIGoalProjetVie].request.method = #POST

--- a/input/fsh/Profiles/TDDUIGoalProjetVie.fsh
+++ b/input/fsh/Profiles/TDDUIGoalProjetVie.fsh
@@ -18,6 +18,8 @@ Description: "Profil de la ressource Goal permettant de représenter le projet d
 
 * subject only Reference(TDDUIPatient or TDDUIPatientINS)
 
+* target.measure.extension contains DataAbsentReason named DataAbsentReason 1..1
+
 Mapping:  ConceptMetier_TDDUIGoalProjetVie
 Source:   TDDUIGoalProjetVie
 Target: "https://interop.esante.gouv.fr/ig/fhir/tddui/sfe_modelisation_contenu.html"

--- a/input/fsh/Profiles/TDDUIGoalProjetVie.fsh
+++ b/input/fsh/Profiles/TDDUIGoalProjetVie.fsh
@@ -12,7 +12,7 @@ Description: "Profil de la ressource Goal permettant de représenter le projet d
 * identifier.system 1..1
 * identifier.system = "https://identifiant-medicosocial-projetvie.esante.gouv.fr"
 
-* status ^short = "Correspondance des statuts métier avec les codes FHIR : ENPREPARATION → planned, ENCOURS → active, TERMINE → completed."
+* lifecycleStatus ^short = "Correspondance des statuts métier avec les codes FHIR : ENPREPARATION → planned, ENCOURS → active, TERMINE → completed."
 
 * lifecycleStatus.extension contains TDDUIStatusAuthor named TDDUIStatusAuthor 0..1
 

--- a/input/fsh/Profiles/TDDUIGoalProjetVie.fsh
+++ b/input/fsh/Profiles/TDDUIGoalProjetVie.fsh
@@ -1,0 +1,35 @@
+Profile: TDDUIGoalProjetVie
+Parent: Goal
+Id: tddui-goal-projet-vie
+Title: "TDDUI Goal Projet Vie"
+Description: "Profil de la ressource Goal permettant de représenter le projet de vie de l'usager."
+
+* identifier 1..1
+* identifier ^short = "Identifiant de l'attente"
+* identifier.value 1..1
+* identifier.value ^example[0].label = "du format d'identifiant à respecter : 3+FINESS/identifiantLocalUsagerESSMS-PDV-idLocalProjetVie"
+* identifier.value ^example[0].valueString = "3480787529/123456789-PDV-1234"
+* identifier.system 1..1
+* identifier.system = "https://identifiant-medicosocial-projetvie.esante.gouv.fr"
+
+* lifecycleStatus.extension contains TDDUIStatusAuthor named TDDUIStatusAuthor 0..1
+
+* description.text 1..1
+
+* subject only Reference(TDDUIPatient or TDDUIPatientINS)
+
+Mapping:  ConceptMetier_TDDUIGoalProjetVie
+Source:   TDDUIGoalProjetVie
+Target: "https://interop.esante.gouv.fr/ig/fhir/tddui/sfe_modelisation_contenu.html"
+Id:       specmetier-to-TDDUIGoalProjetVie
+Title:    "Modèle de contenu DUI"
+* -> "ProjetVie"
+
+* identifier -> "idProjetVie"
+* lifecycleStatus -> "Statut.statut"
+* lifecycleStatus.extension[TDDUIStatusAuthor] -> "Statut.auteur"
+* description.text -> "titreProjetVie"
+* startDate -> "dateDebutProjetVie"
+* target.dueDate -> "dateFinProjetVie"
+* target.detailString -> "aspirationProjetVie"
+* subject -> "Usager"

--- a/input/fsh/Profiles/TDDUIGoalProjetVie.fsh
+++ b/input/fsh/Profiles/TDDUIGoalProjetVie.fsh
@@ -5,12 +5,14 @@ Title: "TDDUI Goal Projet Vie"
 Description: "Profil de la ressource Goal permettant de représenter le projet de vie de l'usager."
 
 * identifier 1..1
-* identifier ^short = "Identifiant de l'attente"
+* identifier ^short = "Identifiant du projet de vie"
 * identifier.value 1..1
 * identifier.value ^example[0].label = "du format d'identifiant à respecter : 3+FINESS/identifiantLocalUsagerESSMS-PDV-idLocalProjetVie"
 * identifier.value ^example[0].valueString = "3480787529/123456789-PDV-1234"
 * identifier.system 1..1
 * identifier.system = "https://identifiant-medicosocial-projetvie.esante.gouv.fr"
+
+* status ^short = "Correspondance des statuts métier avec les codes FHIR : ENPREPARATION → planned, ENCOURS → active, TERMINE → completed."
 
 * lifecycleStatus.extension contains TDDUIStatusAuthor named TDDUIStatusAuthor 0..1
 
@@ -33,5 +35,6 @@ Title:    "Modèle de contenu DUI"
 * description.text -> "titreProjetVie"
 * startDate -> "dateDebutProjetVie"
 * target.dueDate -> "dateFinProjetVie"
-* target.detailString -> "aspirationProjetVie"
+* target.detailString -> "aspirationSouhait"
 * subject -> "Usager"
+* meta.lastUpdated -> "Statut.dateStatut"

--- a/input/fsh/Profiles/TDDUIGoalProjetVie.fsh
+++ b/input/fsh/Profiles/TDDUIGoalProjetVie.fsh
@@ -13,6 +13,7 @@ Description: "Profil de la ressource Goal permettant de représenter le projet d
 * identifier ^short = "Identifiant du projet de vie"
 * identifier contains
     idPDV 1..1 
+* identifier[idPDV] obeys GoalProjetVieIdentifierFormat
 * identifier[idPDV].type = TDDUIGoalIdentifier#PDV
 * identifier[idPDV].value 1..1
 * identifier[idPDV].value ^example[0].label = "du format d'identifiant à respecter : 3+FINESS/identifiantLocalUsagerESSMS-PDV-idLocalProjetVie"
@@ -46,3 +47,8 @@ Title:    "Modèle de contenu DUI"
 * target.detailString -> "aspirationSouhait"
 * subject -> "Usager"
 * meta.lastUpdated -> "Statut.dateStatut"
+
+Invariant: GoalProjetVieIdentifierFormat
+Description: "l'identifiant du projet de vie doit respecter le format :  3+FINESS/identifiantLocalUsagerESSMS-PDV-idLocalProjetVie"
+Severity: #error
+Expression: "value.matches('^3[0-9]{9}/[A-Za-z0-9]+-PDV-[A-Za-z0-9]+$')"

--- a/input/fsh/Profiles/TDDUIGoalProjetVie.fsh
+++ b/input/fsh/Profiles/TDDUIGoalProjetVie.fsh
@@ -4,13 +4,21 @@ Id: tddui-goal-projet-vie
 Title: "TDDUI Goal Projet Vie"
 Description: "Profil de la ressource Goal permettant de représenter le projet de vie de l'usager."
 
-* identifier 1..1
+* identifier 1..
+
+* identifier ^slicing.discriminator.type = #pattern
+* identifier ^slicing.discriminator.path = "type"
+* identifier ^slicing.rules = #open
+
 * identifier ^short = "Identifiant du projet de vie"
-* identifier.value 1..1
-* identifier.value ^example[0].label = "du format d'identifiant à respecter : 3+FINESS/identifiantLocalUsagerESSMS-PDV-idLocalProjetVie"
-* identifier.value ^example[0].valueString = "3480787529/123456789-PDV-1234"
-* identifier.system 1..1
-* identifier.system = "https://identifiant-medicosocial-projetvie.esante.gouv.fr"
+* identifier contains
+    idPDV 1..1 
+* identifier[idPDV].type = TDDUIGoalIdentifier#PDV
+* identifier[idPDV].value 1..1
+* identifier[idPDV].value ^example[0].label = "du format d'identifiant à respecter : 3+FINESS/identifiantLocalUsagerESSMS-PDV-idLocalProjetVie"
+* identifier[idPDV].value ^example[0].valueString = "3480787529/123456789-PDV-1234"
+* identifier[idPDV].system 1..1
+* identifier[idPDV].system = "https://identifiant-medicosocial-projetvie.esante.gouv.fr"
 
 * lifecycleStatus ^short = "Correspondance des statuts métier avec les codes FHIR : ENPREPARATION → planned, ENCOURS → active, TERMINE → completed."
 

--- a/input/fsh/ValueSet/TDDUIGoalIdentifierProjetVie.fsh
+++ b/input/fsh/ValueSet/TDDUIGoalIdentifierProjetVie.fsh
@@ -1,0 +1,9 @@
+ValueSet: TDDUIGoalIdentifierProjetVie
+Id: tddui-goal-Identifier-projet-vie
+Title: "TDDUI Goal Identifier Projet Vie"
+Description: "ValueSet définissant les types de notes pour l'élément Goal.note."
+* ^meta.profile = "http://hl7.org/fhir/StructureDefinition/shareablevalueset"
+* ^experimental = false
+
+* include TDDUIGoalIdentifier#PDV
+

--- a/input/fsh/instances/TDDUIBundleExample.fsh
+++ b/input/fsh/instances/TDDUIBundleExample.fsh
@@ -45,3 +45,8 @@ Usage: #example
 * entry[DUITransportUsager].resource = tddui-task-transport-usager-example
 * entry[DUITransportUsager].request.method = #POST
 * entry[DUITransportUsager].request.url = "TDDUITaskTransportUsager"
+
+* entry[DUIGoalProjetVie].fullUrl = "https://test-server.fr/Goal/tddui-goal-projet-vie-example"
+* entry[DUIGoalProjetVie].resource = tddui-goal-projet-vie-example
+* entry[DUIGoalProjetVie].request.method = #POST
+* entry[DUIGoalProjetVie].request.url = "TDDUIGoalProjetVie"

--- a/input/fsh/instances/TDDUIGoalProjetVieExample.fsh
+++ b/input/fsh/instances/TDDUIGoalProjetVieExample.fsh
@@ -1,0 +1,22 @@
+Instance: tddui-goal-projet-vie-example
+InstanceOf: TDDUIGoalProjetVie
+Title: "TDDUI Goal ProjetVie Example"
+Description: "Exemple du projet de vie d'un usager."
+Usage: #example
+
+* identifier.value = "3480787529/123456789-PDV-1234"
+* identifier.system = "https://identifiant-medicosocial-projetvie.esante.gouv.fr"
+
+* lifecycleStatus = #active
+
+* description.text = "Projet de vie de Mr. Dupont"
+
+* subject = Reference(tddui-patient-ins-example)
+
+* startDate = "2024-01-01"
+
+* target.measure.extension[DataAbsentReason].valueCode = #not-permitted
+
+* target.detailString = "Permettre à Monsieur Dupont de maintenir sa vie à domicile le plus longtemps possible."
+
+* target.dueDate = "2025-01-01"

--- a/input/fsh/instances/TDDUIGoalProjetVieExample.fsh
+++ b/input/fsh/instances/TDDUIGoalProjetVieExample.fsh
@@ -4,8 +4,8 @@ Title: "TDDUI Goal ProjetVie Example"
 Description: "Exemple du projet de vie d'un usager."
 Usage: #example
 
-* identifier.value = "3480787529/123456789-PDV-1234"
-* identifier.system = "https://identifiant-medicosocial-projetvie.esante.gouv.fr"
+* identifier[idPDV].value = "3480787529/123456789-PDV-1234"
+* identifier[idPDV].system = "https://identifiant-medicosocial-projetvie.esante.gouv.fr"
 
 * lifecycleStatus = #active
 

--- a/input/images-source/mapping_TDDUIGoalProjetVie.plantuml
+++ b/input/images-source/mapping_TDDUIGoalProjetVie.plantuml
@@ -9,7 +9,7 @@ map "description" as description #DarkGray {
 }
 
 map "target" as target #DarkGray {
-    aspirationProjetVie => detailString
+    aspirationSouhait => detailString
     dateFinProjetVie => dueDate
 }
 
@@ -21,6 +21,7 @@ map "**ProjetVie : TDDUIGoalProjetVie**" as ProjetVie #fb8072 {
     idProjetVie => identifier
     dateDebutProjetVie => startDate
     Statut.statut => lifecycleStatus
+    Statut.dateStatut => meta.lastUpdated
     description *-> description
     target *--> target
 }

--- a/input/images-source/mapping_TDDUIGoalProjetVie.plantuml
+++ b/input/images-source/mapping_TDDUIGoalProjetVie.plantuml
@@ -1,0 +1,31 @@
+@startuml
+
+map "Statut.statut : lifecycleStatus" as Statutstatut #DarkGray {
+    Statut.auteur => <&plus> TDDUIStatusAuthor
+}
+
+map "description" as description #DarkGray {
+    titreProjetVie => text
+}
+
+map "target" as target #DarkGray {
+    aspirationProjetVie => detailString
+    dateFinProjetVie => dueDate
+}
+
+object "**TDDUIPatient/TDDUIPatientINS**" as TDDUIPatient_subject #b3de69 {
+    Usager
+}
+
+map "**ProjetVie : TDDUIGoalProjetVie**" as ProjetVie #fb8072 {
+    idProjetVie => identifier
+    dateDebutProjetVie => startDate
+    Statut.statut => lifecycleStatus
+    description *-> description
+    target *--> target
+}
+
+ProjetVie::Statut.statut -u-> Statutstatut
+ProjetVie -d-> TDDUIPatient_subject : subject
+
+@enduml

--- a/input/images-source/mapping_TDDUIGoalProjetVie.plantuml
+++ b/input/images-source/mapping_TDDUIGoalProjetVie.plantuml
@@ -18,7 +18,7 @@ object "**TDDUIPatient/TDDUIPatientINS**" as TDDUIPatient_subject #b3de69 {
 }
 
 map "**ProjetVie : TDDUIGoalProjetVie**" as ProjetVie #fb8072 {
-    idProjetVie => identifier
+    idProjetVie => identifier:idPDV
     dateDebutProjetVie => startDate
     Statut.statut => lifecycleStatus
     Statut.dateStatut => meta.lastUpdated

--- a/input/pagecontent/description_flux_1_transmission_donnees_dui.md
+++ b/input/pagecontent/description_flux_1_transmission_donnees_dui.md
@@ -42,6 +42,7 @@ Les différentes ressources sont véhiculées via l'élément : Bundle.entry. Le
 * [TDDUIObservationCauseMortalite](StructureDefinition-tddui-observation-cause-mortalite.html) représentant les causes de mortalité.
 * [TDDUIObservationMobiliteUsager](StructureDefinition-tddui-observation-mobilite-usager.html) représentant la mobilité de l'usager.
 * [TDDUIObservationPeriodeScolaire](StructureDefinition-tddui-observation-periode-scolaire.html) représentant la période scolaire de l'usager.
+* [TDDUIGoalProjetVie](StructureDefinition-tddui-goal-projet-vie.html) représentant le projet de vie de l'usager.
 
 Pour toutes ces ressources, seule la création est possible via l'intéraction FHIR <a href="https://hl7.org/fhir/R4/http.html#create">Create</a>.
 

--- a/input/pagecontent/mapping_fonctionnel_FHIR.md
+++ b/input/pagecontent/mapping_fonctionnel_FHIR.md
@@ -11,6 +11,10 @@ Ce mapping représente les données fonctionnelles trouvant leur équivalence da
 
 <div>{%include mapping_TDDUIObservationPeriodeScolaire.svg%}</div>
 
+### Mapping ProjetVie
+
+<div>{%include mapping_TDDUIGoalProjetVie.svg%}</div>
+
 ### Mapping Contact
 <div>{%include mapping_TDDUIRelatedPersonContact.svg%}</div>
 


### PR DESCRIPTION
## Description des changements

* Ajout du profil TDDUIGoalProjetVie
* Ajout d'un exemple conforme au profil
* Ajout de l'extension DataAbsentReason sur l'élément target.measure pour contourner l'invariant
* Ajout du mapping (SD/Diagramme)
* Mise à jour de la description du flux 1
* Mise à jour du profil du Bundle et de son exemple
* Mise à jour des CapabilityStatement

## Preview

https://ansforge.github.io/IG-fhir-medicosocial-transfert-donnees-dui/448-contenu-fhir---ajout-du-projet-de-vie/ig

